### PR TITLE
Adds new mcp routes `/` and `robots`

### DIFF
--- a/lib/mqtt-master.js
+++ b/lib/mqtt-master.js
@@ -19,6 +19,7 @@ var MqttMaster = module.exports = function MqttMaster(broker, mcp, prefix) {
   this.client = {};
   this.topics = {};
 
+  // You can pass a prefix to the topic master to preceed your topic names
   this.prefix = prefix ? '/' + prefix : '';
   this.sender = prefix + (Math.random() * Date.now());
 };
@@ -36,12 +37,15 @@ MqttMaster.prototype.start = function() {
     });
 
     this.client.on('message', function(topic, payload) {
+      var data = null, sender = null;
+
       if (!!payload && (payload.length > 0)) {
-        payload = JSON.parse(payload);
+        data = JSON.parse(payload);
+        sender = data.sender;
       }
 
-      if ((!!payload) && (payload.sender !== this.sender)) {
-        this.emit(topic, payload);
+      if (sender !== this.sender) {
+        this.emit(topic, data);
       }
     }.bind(this));
 
@@ -55,15 +59,13 @@ MqttMaster.prototype.start = function() {
 };
 
 MqttMaster.prototype._subscribeItems = function(topic, items, callback) {
-  _.forIn(items, function(item, name) {
-    var topicName;
+  _.forIn(items, function(item, key) {
+    key = key.toLowerCase();
+    var fullTopic = this.prefix + topic + key;
 
-    name = name.toLowerCase();
-    topicName = topic + name;
-
-    if (!this.topics[topicName]) {
-      this.topics[name] = topicName;
-      callback(topicName, name, item);
+    if (!this.topics[fullTopic]) {
+      this.topics[fullTopic] = fullTopic;
+      callback(fullTopic, item);
     }
   }, this);
 };
@@ -72,53 +74,59 @@ MqttMaster.prototype.subscribeMCP = function() {
   console.log('Setting up MQTT API...');
   console.log('Subscribing MCP...');
 
-  var callback = function(topicName, name, robots) {
+  var callback = function(topic, mcp) {
+    var rootTopic = topic + '/',
+        robotsTopic = topic + '/robots';
 
-    this.on(this.prefix + topicName, function() {
-      var robotNames = _.keys(robots),
-          payload = this._stringify({ robots: robotNames });
+    var rootCB = function() {
+      var payload = this._stringify(mcp.toJSON());
 
-      this.client.publish(this.prefix + topicName, payload);
+      this.publish(rootTopic, payload);
+      this.publish(topic, payload);
+    }.bind(this);
+
+    this.on(topic, rootCB);
+    this.on(rootTopic, rootCB);
+    this.on(robotsTopic, function() {
+      var robotsNames = _.map(mcp.robots, function(val, key) {
+            return key.toLowerCase();
+          }),
+          payload = this._stringify({ robots: robotsNames });
+
+      this.publish(robotsTopic, payload);
     }.bind(this));
 
-    this.client.subscribe(this.prefix + topicName);
+    this.subscribe([topic, rootTopic, robotsTopic]);
   }.bind(this);
 
-  this._subscribeItems('/api/', { robots: this.mcp.robots }, callback);
+  this._subscribeItems('/api', { '': this.mcp }, callback);
 };
 
 MqttMaster.prototype.subscribeRobots = function() {
   console.log('Subscribing robots...');
 
-  var robots = this.mcp.robots;
+  var callback = function(topic, robot) {
+    var devicesTopic = topic + '/devices';
 
-  var callback = function(topicName, name, robot) {
     var innerCB = function() {
       var devices = _.keys(robot.devices),
           payload = this._stringify({
             devices: devices
           });
 
-      this.client.publish(this.prefix + topicName, payload);
-      this.client.publish(this.prefix + topicName + '/devices', payload);
+      this.publish(topic, payload);
+      this.publish(devicesTopic, payload);
     }.bind(this);
 
-    var mainTopic = this.prefix + topicName,
-        devsTopic = mainTopic + '/devices',
-        topics = [
-          mainTopic,
-          devsTopic
-        ];
+    this.on(topic, innerCB);
+    this.on(devicesTopic, innerCB);
 
-    this.on(mainTopic, innerCB);
-    this.on(devsTopic, innerCB);
+    this.subscribe([topic, devicesTopic]);
 
-    this.client.subscribe(topics);
-
-    this._addDefaultListeners(topicName, name, robot);
+    this._addDefaultListeners(topic, robot);
   }.bind(this);
 
-  this._subscribeItems('/api/robots/', robots, callback);
+  this._subscribeItems('/api/robots/', this.mcp.robots, callback);
 };
 
 MqttMaster.prototype.subscribeDevices = function(robot) {
@@ -130,39 +138,39 @@ MqttMaster.prototype.subscribeDevices = function(robot) {
   this._subscribeItems(topic, robot.devices, callback);
 };
 
-MqttMaster.prototype._addDefaultListeners = function(topicName, name, item) {
-  var messageTopic = topicName + '/message',
-      commandsTopic = topicName + '/commands',
-      eventsTopic = topicName + '/events',
-      commandTopic = topicName + '/command';
+MqttMaster.prototype._addDefaultListeners = function(topic, item) {
+  var messageTopic = topic + '/message',
+      commandsTopic = topic + '/commands',
+      eventsTopic = topic + '/events',
+      commandTopic = topic + '/command';
 
-  this.on(this.prefix + messageTopic, function(payload) {
-    this.client.publish(
-      this.prefix + messageTopic,
+  this.on(messageTopic, function(payload) {
+    this.publish(
+      messageTopic,
       this._stringify({
         data: payload
       }));
   }.bind(this));
 
-  this.on(this.prefix + commandsTopic, function() {
+  this.on(commandsTopic, function() {
     var commands = _.keys(item.commands),
         payload = this._stringify({ commands: commands });
 
-    this.client.publish(this.prefix + commandsTopic, payload);
+    this.publish(commandsTopic, payload);
   }.bind(this));
 
-  this.on(this.prefix + eventsTopic, function() {
+  this.on(eventsTopic, function() {
     var events = item.events,
         payload = this._stringify({ events: events });
 
-    this.client.publish(this.prefix + eventsTopic, payload);
+    this.publish(eventsTopic, payload);
   }.bind(this));
 
-  this.on(this.prefix + commandTopic, function(payload) {
+  this.on(commandTopic, function(payload) {
     var ret = item.commands[payload.command].apply(item, payload.args);
 
-    this.client.publish(
-      this.prefix + commandTopic,
+    this.publish(
+      commandTopic,
       this._stringify({
         command: payload.command,
         returned: ret
@@ -171,43 +179,51 @@ MqttMaster.prototype._addDefaultListeners = function(topicName, name, item) {
   }.bind(this));
 
   var subscribeTo = [
-    this.prefix + messageTopic,
-    this.prefix + commandsTopic,
-    this.prefix + eventsTopic,
-    this.prefix + commandTopic
+    messageTopic,
+    commandsTopic,
+    eventsTopic,
+    commandTopic
   ];
 
   // Custom Commands
   _.forIn(item.commands, function(command, cname) {
-    this.on(this.prefix + topicName + '/' + cname, function(payload) {
+    this.on(topic + '/' + cname, function(payload) {
       var args = _.toArray(payload),
           ret = command.apply(item, args);
 
       ret = ret || null;
 
-      this.client.publish(
-        this.prefix + topicName + '/' + cname,
+      this.publish(
+        topic + '/' + cname,
         this._stringify({ returned: ret })
       );
     }.bind(this));
 
-    subscribeTo.push(this.prefix + topicName + '/' + cname);
+    subscribeTo.push(topic + '/' + cname);
   }, this);
 
   // Custom Events
   _.forIn(item.events, function(eventName) {
     item.on(eventName, function() {
-      this.client.publish(
-        this.prefix + topicName + '/' + eventName,
+      this.publish(
+        topic + '/' + eventName,
         this._stringify({ arguments: arguments })
       );
     }.bind(this));
   }, this);
 
-  this.client.subscribe(subscribeTo);
+  this.subscribe(subscribeTo);
 };
 
 MqttMaster.prototype._stringify = function(payload) {
   payload.sender = this.sender;
   return JSON.stringify(payload);
+};
+
+MqttMaster.prototype.subscribe = function(topics) {
+  this.client.subscribe(topics);
+};
+
+MqttMaster.prototype.publish = function(topic, payload) {
+  this.client.publish(topic, payload);
 };


### PR DESCRIPTION
User can now pull MCP json by subscribing to:

``` javascript
'use strict';

var mqtt    = require('mqtt');
var client  = mqtt.connect('mqtt://test.mosquitto.org');

client.on('message', function (topic, payload) {
  var sender, data;

  if (!!payload && (payload.length > 0)) {
    data = JSON.parse(payload);
    sender = data.sender;
  }

  if (sender !== 'self') {
    console.log('topic ==>', topic);
    console.log('payload ==>', data);
  }
});

client.subscribe('/cybot/api');
client.publish('/cybot/api');

```
